### PR TITLE
fix: guard against missing data key in post_processing

### DIFF
--- a/laser_mind_client/laser_mind_client.py
+++ b/laser_mind_client/laser_mind_client.py
@@ -181,6 +181,8 @@ class LaserMind:
         return result, status
 
     def post_processing (self, result):
+        if 'data' not in result:
+            return result
         if "method" in result['data']:
             if result['data']["method"] == "solve_coupling_matrix_lpu":
                 num_runs = result['data']["num_runs"]


### PR DESCRIPTION
solve_qubo results don't have a data wrapper, so post_processing was crashing with KeyError on all QUBO calls since LSSW-1262.